### PR TITLE
Fixed a typo in memory-bank.md

### DIFF
--- a/.clinerules/memory-bank.md
+++ b/.clinerules/memory-bank.md
@@ -15,7 +15,7 @@ The Memory Bank consists of core files and optional context files, all in Markdo
 
 ```mermaid
 flowchart TD
-    PB[projectbrief.md] --> PC[productContext.md]
+    PB[projectBrief.md] --> PC[productContext.md]
     PB --> SP[systemPatterns.md]
     PB --> TC[techContext.md]
     
@@ -27,7 +27,7 @@ flowchart TD
 ```
 
 ### Core Files (Required)
-1. `projectbrief.md`
+1. `projectBrief.md`
    - Foundation document that shapes all other files
    - Created at project start if it doesn't exist
    - Defines core requirements and goals


### PR DESCRIPTION
I got annoyed at it creating one file that didn't match the pattern of kneeling camel case.