### PR TITLE
docs: update workflow naming to flatcase and clarify markdown default

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,14 @@ Your contribution will be reviewed, and once approved, it will be merged into th
 
 To add your own Cline workflow:
 
+#### Workflow Naming Convention
+
+- **Flatcase** means using all lowercase letters with no separators (e.g., `myawesomeworkflow`).
+- If your workflow file does not have an extension, it will be treated as a markdown file by default.
+
 1.  **Fork** this repository.
-2.  **Create** a new Markdown file (`.md`) for your workflow inside the `workflows/` directory.
-3.  **Name** your file using `kebab-case` (e.g., `my-awesome-workflow.md`).
+2.  **Create** a new workflow file inside the `workflows/` directory.
+3.  **Name** your file using flatcase (e.g., `myawesomeworkflow`). See the convention above. If your file does not have an extension, it will be treated as a markdown file by default.
 4.  **Add** the content of your workflow to the file.
 5.  **Commit** your changes and push them to your fork.
 6.  **Submit** a Pull Request (PR) to the main repository.

--- a/workflows/create-new-workflow.md
+++ b/workflows/create-new-workflow.md
@@ -13,7 +13,9 @@ Guide the user through the process of creating a new standardized Cline workflow
    
 2. Use the `ask_followup_question` command to ask the USER for a concise name for the workflow.
    
-3. Determine the appropriate filename using kebab-case format (e.g., `analyze-system-requirements.md`).
+3. Determine the appropriate filename using flatcase format (e.g., `analyzesystemrequirements`).
+   - All files in the workflow folder should be treated as markdown files by default if they do not have a file extension.
+   - Use flatcase for filenames (e.g., `analyzesystemrequirements`), not kebab-case.
 
 4. Inform the USER of the upcoming workflow file creation process and the main steps they will be asked to complete.
 
@@ -43,13 +45,13 @@ Guide the user through the process of creating a new standardized Cline workflow
 
 1. Determine if the `.clinerules/workflows` directory exists. If not, create it.
 
-2. Create a markdown file named `.clinerules/workflows/{{workflow-filename}}.md` with the following structure:
+2. Create a markdown file named `.clinerules/workflows/{{workflowfilename}}` (using flatcase, no extension unless explicitly provided). If the filename does not have an extension, treat it as a markdown file by default. The file should have the following structure:
    i. Task definition with name attribute
    ii. Task objective section
    iii. Detailed sequence steps section with proper formatting
    iv. Proper tool references and formatting conventions
 
-3. Use the `read_file` command to read the `.clinerules/workflow-template.md` file to ensure the new workflow follows all conventions.
+3. Use the `read_file` command to read the `.clinerules/workflowtemplate` file to ensure the new workflow follows all conventions.
 
 4. Use the `write_to_file` command to write the completed workflow file.
 


### PR DESCRIPTION
Update documentation and workflow instructions to require flatcase naming for workflow files and treat files without extension as markdown by default. 

- This will simplify using workflows similar to slash commands. eg `/gitpush` to push to git similar to `/newtask` or `/smol`

An alternate solution could be to maintain a mapping of workflow filename to its "alias" to be used in cline.